### PR TITLE
Fix syntax error in string concatenation

### DIFF
--- a/lib/Curve/MontCurve/Point.php
+++ b/lib/Curve/MontCurve/Point.php
@@ -45,7 +45,7 @@ class Point extends \Elliptic\Curve\BaseCurve\Point
         if( $this->isInfinity() )
             return "<EC Point Infinity>";
         return "<EC Point x: " . $this->x->fromRed()->toString(16, 2) .
-            " z: " . $this->z->fromRed()->toString(16, 2) + ">";
+            " z: " . $this->z->fromRed()->toString(16, 2) . ">";
     }
 
     public function isInfinity() {


### PR DESCRIPTION
This will be a compiler error in PHP 8 and prevent running of this script.

I found this with the [PHPCompatibility Checker](https://github.com/PHPCompatibility/PHPCompatibility).