### PR TITLE
Accommodate currently-supported version of PHPUnit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ composer.lock
 .project
 .settings
 .buildpath
+/.idea

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,20 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         colors="true"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          stopOnFailure="false"
-         syntaxCheck="true"
          verbose="true"
 >
     <testsuites>
-        <testsuite>
+        <testsuite name="AllTests">
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
+    <coverage>
+        <exclude>
             <directory suffix=".php">lib/</directory>
-        </whitelist>
-    </filter>
+        </exclude>
+    </coverage>
 </phpunit>

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -1,7 +1,7 @@
 <?php
 require_once __DIR__ . "/../vendor/autoload.php";
 
-class ApiTest extends PHPUnit_Framework_TestCase {
+class ApiTest extends \PHPUnit\Framework\TestCase {
     public function test_should_instatiate_with_valid_curve_secp256k1() {
         $ec = new \Elliptic\EC('secp256k1');
 
@@ -9,9 +9,9 @@ class ApiTest extends PHPUnit_Framework_TestCase {
         $this->assertInstanceOf(\Elliptic\EC::class, $ec);
     }
 
-    
+
     public function test_should_throw_error_with_invalid_curve() {
-        $this->setExpectedException("Exception");
+        $this->expectException(\Exception::class);
         $ec = new \Elliptic\EC('nonexistent-curve');
     }
 }

--- a/tests/CurveTest.php
+++ b/tests/CurveTest.php
@@ -3,7 +3,7 @@ require_once __DIR__ . "/../vendor/autoload.php";
 
 use BN\BN;
 
-class CurveTest extends PHPUnit_Framework_TestCase {
+class CurveTest extends \PHPUnit\Framework\TestCase {
     public function test_should_work_with_example_curve() {
         $curve = new \Elliptic\Curve\ShortCurve(array(
             "p" => '1d',

--- a/tests/ECDHTest.php
+++ b/tests/ECDHTest.php
@@ -1,7 +1,7 @@
 <?php
 require_once __DIR__ . "/../vendor/autoload.php";
 
-class ECDHTest extends PHPUnit_Framework_TestCase {
+class ECDHTest extends \PHPUnit\Framework\TestCase {
     public function test_should_work_with_secp256k1_curve() {
         $this->doTest('secp256k1');
     }

--- a/tests/ECDSATest.php
+++ b/tests/ECDSATest.php
@@ -2,7 +2,7 @@
 require_once __DIR__ . "/../vendor/autoload.php";
 use BN\BN;
 
-class ECDSATest extends PHPUnit_Framework_TestCase {
+class ECDSATest extends \PHPUnit\Framework\TestCase {
 
     function ECDSACurveNames() {
         return [
@@ -276,7 +276,7 @@ class ECDSATest extends PHPUnit_Framework_TestCase {
         $key = $ecdsa->keyFromPublic($vector["pub"], 'hex');
         $msg = $vector["message"];
         $sig = $vector["sig"];
-        
+
         $actual = $ecdsa->verify($msg, $sig, $key);
         $this->assertEquals($actual, $vector["result"]);
     }
@@ -293,7 +293,7 @@ class ECDSATest extends PHPUnit_Framework_TestCase {
             "entropy" => hash('sha256', 'hello world', true)
         ));
         $this->assertEquals(
-            $keys->getPrivate('hex'), 
+            $keys->getPrivate('hex'),
             '6160edb2b218b7f1394b9ca8eb65a72831032a1f2f3dc2d99291c2f7950ed887');
     }
 
@@ -312,7 +312,7 @@ class ECDSATest extends PHPUnit_Framework_TestCase {
         $message =
             'f75c6b18a72fabc0f0b888c3da58e004f0af1fe14f7ca5d8c897fe164925d5e9';
 
-        $this->setExpectedException("Exception");
+        $this->expectException(\Exception::class);
         $ec->recoverPubKey($message, [
             "r" => 'fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140',
             "s" => '8887321be575c8095f789dd4c743dfe42c1820f9231f98a962b210e3ac2452a3'

--- a/tests/ED25519Test.php
+++ b/tests/ED25519Test.php
@@ -6,7 +6,7 @@ use \Elliptic\Utils;
 
 function toHex($arg) { return strtoupper(Utils::toHex($arg)); }
 
-class ED25519Test extends PHPUnit_Framework_TestCase {
+class ED25519Test extends \PHPUnit\Framework\TestCase {
     public function derivations() {
         $data = json_decode( file_get_contents(__DIR__ . "/fixtures/derivation-fixtures"), true);
         $data = array_slice($data, 0, 50);

--- a/tests/HmacDRBGTest.php
+++ b/tests/HmacDRBGTest.php
@@ -1,7 +1,7 @@
 <?php
 require_once __DIR__ . "/../vendor/autoload.php";
 
-class HmacDRBGTest extends PHPUnit_Framework_TestCase {
+class HmacDRBGTest extends \PHPUnit\Framework\TestCase {
 
     public function test_should_support_hmac_drbg_sha256() {
         function doDrbg($opt) {

--- a/tests/PointCodecTest.php
+++ b/tests/PointCodecTest.php
@@ -1,7 +1,7 @@
 <?php
 require_once __DIR__ . "/../vendor/autoload.php";
 
-class PointCodecTest extends PHPUnit_Framework_TestCase {
+class PointCodecTest extends \PHPUnit\Framework\TestCase {
     function makeShortTest($definition) {
         $curve = \Elliptic\Curves::getCurve("secp256k1")->curve;
 
@@ -36,12 +36,12 @@ class PointCodecTest extends PHPUnit_Framework_TestCase {
     static $shortPointOddY;
 
     public function test_should_throw_when_trying_to_decode_random_bytes() {
-        $this->setExpectedException("Exception");
+        $this->expectException(\Exception::class);
         \Elliptic\Curves::getCurve("secp256k1")->curve->decodePoint(
             '05' .
             '79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798');
     }
-    
+
     public function test_should_be_able_to_encode_and_decode_a_short_curve_point_with_even_Y() {
         $f = $this->makeShortTest(self::$shortPointEvenY);
         $f();


### PR DESCRIPTION
This PR makes the unit tests compatible with PHPUnit 9. It considers the following information:

- *PHP* current stable is version 8.0, old stable is version 7.4, PHP 7.3 is not under active support, and **receives only security patches through December 6 2021**, at which point it reaches end-of-life. Earlier versions of PHP are already at end-of-life. See https://www.php.net/supported-versions.php
- Currently supported *PHPUnit version 9* requires PHP 7.3 or newer, and receives bug fixes until February 4, 2022. See https://phpunit.de/announcements/phpunit-9.html
- *PHPUnit version 8*, though it supports PHP 7.2 or newer, **receives bug fixes only until February 5, 2021**. See https://phpunit.de/announcements/phpunit-8.html
- The unit tests appear to have been written using PHPUnit 5.

The minor changes are as follows:

- Update phpunit configuration to prevent warnings
- Version 9.3.0 introduced changes to the configuration file that should be accommodated.
https://github.com/sebastianbergmann/phpunit/blob/a0d6b21c6c8f6564212a1a14292d230ee35eba6d/ChangeLog-9.3.md#930---2020-08-07
- Replace `PHPUnit_Framework_TestCase` with `\PHPUnit\Framework\TestCase`
- Replace `$this->setExpectedException()` with `$this->expectException(\Exception::class);`