### PR TITLE
Prevents a warning in PHP 8.1 - Point class uses ReturnTypeWillChange attribute on jsonSerialize

### DIFF
--- a/lib/Curve/ShortCurve/Point.php
+++ b/lib/Curve/ShortCurve/Point.php
@@ -81,6 +81,7 @@ class Point extends \Elliptic\Curve\BaseCurve\Point implements JsonSerializable
     }
 
     //toJSON()
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $res = array($this->x, $this->y);


### PR DESCRIPTION
Adding mixed return type would require php 8.0

Fixes https://github.com/simplito/elliptic-php/issues/40