### PR TITLE
Modernize: add `#[\SensitiveParameter]`

### DIFF
--- a/lib/EC.php
+++ b/lib/EC.php
@@ -40,11 +40,13 @@ class EC
             $this->hash = $options["curve"]->hash;
     }
 
-    public function keyPair($options) {
+    public function keyPair(#[\SensitiveParameter]
+        $options) {
         return new KeyPair($this, $options);
     }
 
-    public function keyFromPrivate($priv, $enc = false) {
+    public function keyFromPrivate(#[\SensitiveParameter]
+        $priv, $enc = false) {
         return KeyPair::fromPrivate($this, $priv, $enc);
     }
 
@@ -87,7 +89,8 @@ class EC
         return $msg->sub($this->n);
     }
 
-    public function sign($msg, $key, $enc = null, $options = null)
+    public function sign($msg, #[\SensitiveParameter]
+                         $key, $enc = null, $options = null)
     {
         if( !is_string($enc) )
         {

--- a/lib/EC/KeyPair.php
+++ b/lib/EC/KeyPair.php
@@ -10,7 +10,8 @@ class KeyPair
     public $pub;
     public $priv;
 
-    function __construct($ec, $options)
+    function __construct($ec, #[\SensitiveParameter]
+                         $options)
     {
         $this->ec = $ec;
 
@@ -35,7 +36,8 @@ class KeyPair
         ));
     }
 
-    public static function fromPrivate($ec, $priv, $enc)
+    public static function fromPrivate($ec, #[\SensitiveParameter]
+                                       $priv, $enc)
     {
         if( $priv instanceof KeyPair )
             return $priv;
@@ -88,7 +90,8 @@ class KeyPair
         return $this->priv;
     }
 
-    private function _importPrivate($key, $enc)
+    private function _importPrivate(#[\SensitiveParameter]
+        $key, $enc)
     {
         $this->priv = new BN($key, (isset($enc) && $enc) ? $enc : 16);
 

--- a/lib/EdDSA.php
+++ b/lib/EdDSA.php
@@ -31,7 +31,8 @@ class EdDSA {
      * @param {Array|String|KeyPair} secret - secret bytes or a keypair
      * @returns {Signature} - signature
      */
-    public function sign($message, $secret) {
+    public function sign($message, #[\SensitiveParameter]
+						 $secret) {
         $message = Utils::parseBytes($message);
         $key = $this->keyFromSecret($secret);
         $r = $this->hashInt($key->messagePrefix(), $message);
@@ -72,7 +73,8 @@ class EdDSA {
         return KeyPair::fromPublic($this, $pub);
     }
 
-    public function keyFromSecret($secret) {
+    public function keyFromSecret(#[\SensitiveParameter]
+		$secret) {
         return KeyPair::fromSecret($this, $secret);
     }
 

--- a/lib/EdDSA/KeyPair.php
+++ b/lib/EdDSA/KeyPair.php
@@ -15,7 +15,8 @@ class KeyPair {
 * @param {Array<Byte>} [params.pub] - public key point encoded as bytes
 *
 */
-    function __construct($eddsa, $params) {
+    function __construct($eddsa, #[\SensitiveParameter]
+						 $params) {
         $this->eddsa = $eddsa;
         $this->_secret = isset($params["secret"]) ? Utils::parseBytes($params["secret"]) : null;
         if (!isset($params["pub"])) {
@@ -35,7 +36,8 @@ class KeyPair {
         return new KeyPair($eddsa, [ "pub" => $pub ]);
     }
 
-    public static function fromSecret($eddsa, $secret) {
+    public static function fromSecret($eddsa, #[\SensitiveParameter]
+									  $secret) {
         if ($secret instanceof KeyPair)
             return $secret;
         return new KeyPair($eddsa, [ "secret" => $secret ]);


### PR DESCRIPTION
There is no behavior change except tagging some parameters with `#[\SensitiveParameter]`.
Unit tests pass, with one deprecation.

Solves #45

The formatting may look slightly odd, but new tags should be last thing on line, since that's new feature of php, and older versions can continue to work. For php 7.X the tag looks just like comment, so the tag must be last thing on line to preserve php 7.X compatibility.

Docs to [SensitiveParameter](https://www.php.net/manual/en/class.sensitiveparameter.php)