### PR TITLE
Checks for PHP Version when using (deprecated) assert_options

### DIFF
--- a/lib/Curve/EdwardsCurve.php
+++ b/lib/Curve/EdwardsCurve.php
@@ -31,7 +31,7 @@ class EdwardsCurve extends BaseCurve
         $this->c2 = $this->c->redSqr();
         $this->d = (new BN($conf["d"], 16))->toRed($this->red);
         $this->dd = $this->d->redAdd($this->d);
-        if (assert_options(ASSERT_ACTIVE)) {
+        if (PHP_VERSION_ID < 80300 && assert_options(ASSERT_ACTIVE)) {
             assert(!$this->twisted || $this->c->fromRed()->cmpn(1) == 0);
         }
         $this->oneC = ($conf["c"] | 0) == 1;

--- a/lib/Curve/ShortCurve.php
+++ b/lib/Curve/ShortCurve.php
@@ -65,7 +65,7 @@ class ShortCurve extends BaseCurve
             else
             {
                 $lambda = $lambdas[1];
-                if (assert_options(ASSERT_ACTIVE)) {
+                if (PHP_VERSION_ID < 80300 && assert_options(ASSERT_ACTIVE)) {
                     assert($this->g->mul($lambda)->x->cmp($this->g->x->redMul($beta)) === 0);
                 }
             }

--- a/lib/HmacDRBG.php
+++ b/lib/HmacDRBG.php
@@ -43,7 +43,7 @@ class HmacDRBG
         $nonce  = Utils::toBin($options["nonce"], $options["nonceEnc"]);
         $pers  = Utils::toBin($options["pers"], $options["persEnc"]);
         
-        if (assert_options(ASSERT_ACTIVE)) {
+        if (PHP_VERSION_ID < 80300 && assert_options(ASSERT_ACTIVE)) {
             assert(strlen($entropy) >= ($this->minEntropy / 8));
         }
         $this->_init($entropy, $nonce, $pers);


### PR DESCRIPTION
PHP 8.3 displays a deprecation message for assert_options(), which will be gone as of PHP 9. This is a backwards compatible fix, checking for PHP version before performing assert_options(). As of PHP 9.3 assert() implicitly checks wether to use or skip assert(), so this operations becomes redundant.